### PR TITLE
yeonsup / 8월 4주차 / 4문제

### DIFF
--- a/yeonsup/boj/Boj_1715.java
+++ b/yeonsup/boj/Boj_1715.java
@@ -1,0 +1,37 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+public class Boj_1715 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        Queue<Long> queue = new PriorityQueue<>();
+
+        int number = Integer.parseInt(bf.readLine());
+        long sum = 0;
+        long total = 0;
+
+        for (int i = 0; i < number; i++) {
+            long s = Long.parseLong(bf.readLine());
+            queue.offer(s);
+        }
+
+        while (queue.size() > 1) {
+            long a = queue.poll();
+            long b = queue.poll();
+
+            sum = a + b;
+            total += sum;
+            queue.offer(sum);
+        }
+
+        System.out.println(total);
+
+        bf.close();
+    }
+}

--- a/yeonsup/boj/Boj_1931.java
+++ b/yeonsup/boj/Boj_1931.java
@@ -1,0 +1,74 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+class Meeting {
+
+    long start;
+    long end;
+
+    public Meeting(long start, long end) {
+        this.start = start;
+        this.end = end;
+    }
+}
+
+
+public class Boj_1931 {
+
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        List<Meeting> list = new ArrayList<>();
+        int number = Integer.parseInt(bf.readLine());
+        long last = 0;
+        int cnt = 0;
+
+        for (int i = 0; i < number; i++) {
+            String[] time = bf.readLine().split(" ");
+            list.add(new Meeting(Long.parseLong(time[0]), Long.parseLong(time[1])));
+        }
+
+        list.sort((o1, o2) -> {
+            if(o1.end <= o2.end) {
+                if(o1.start < o2.start) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+            return 1;
+        });
+
+        for (int i = 0; i < list.size(); i++) {
+            if (last <= list.get(i).start) {
+                last = list.get(i).end;
+                cnt++;
+            }
+        }
+
+        System.out.println(cnt);
+
+        bf.close();
+    }
+}
+
+/*
+11
+1 4
+3 5
+0 6
+5 7
+3 8
+5 9
+6 10
+8 11
+8 12
+2 13
+12 14
+ */

--- a/yeonsup/boj/Boj_1946.java
+++ b/yeonsup/boj/Boj_1946.java
@@ -1,0 +1,83 @@
+package boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+class Applicant {
+    private int document;
+    private int interview;
+
+    public Applicant(int document, int interview) {
+        this.document = document;
+        this.interview = interview;
+    }
+
+    public boolean isInvBetter(int interview) {
+        if(interview < this.interview) return true;
+        return false;
+    }
+
+    public int getInterview() {
+        return interview;
+    }
+
+    public int getDocument() {
+        return document;
+    }
+}
+
+public class Boj_1946 {
+
+    public int getMaxNumNewEmployees(List<Applicant> applicants) {
+        int cnt = 1;
+        int min = applicants.get(0).getInterview();
+        for (int i = 1; i < applicants.size(); i++) {
+            int interview = applicants.get(i).getInterview();
+            if(interview < min) {
+                cnt++;
+                min = interview;
+            }
+        }
+
+        return cnt;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        Boj_1946 boj1946 = new Boj_1946();
+        int testCnt = Integer.parseInt(br.readLine());
+
+
+        while (testCnt > 0) {
+            List<Applicant> list = new ArrayList<>();
+            int n = Integer.parseInt(br.readLine());
+
+            for (int i = 0; i < n; i++) {
+                String[] app = br.readLine().split(" ");
+                list.add(new Applicant(Integer.parseInt(app[0]), Integer.parseInt(app[1])));
+            }
+
+            list.sort(new Comparator<Applicant>() {
+                @Override
+                public int compare(Applicant o1, Applicant o2) {
+                    if(o1.getDocument() > o2.getDocument()) {
+                        return 1;
+                    }
+                    return -1;
+                }
+            });
+
+            int cnt = boj1946.getMaxNumNewEmployees(list);
+
+            System.out.println(cnt);
+
+            testCnt--;
+        }
+
+    }
+}

--- a/yeonsup/pgs/Pog_42860.java
+++ b/yeonsup/pgs/Pog_42860.java
@@ -1,0 +1,44 @@
+package pog;
+
+
+public class Pog_42860 {
+
+    private int getMinChangeCount(char a, char target) {
+        int result = Math.min(target - a, (91 - 'A') - (target - a));
+        return result;
+    }
+
+    private int getLastA(char[] alphabets, int index) {
+        int move = index;
+        while (move < alphabets.length && alphabets[move] == 'A') {
+            move++;
+        }
+        return move;
+    }
+    public int solution(String name) {
+        int answer = 0;
+        int move = name.length() - 1;
+        char[] alphabets = name.toCharArray();
+
+        for (int i = 0; i < alphabets.length; i++) {
+            answer += getMinChangeCount('A', alphabets[i]);
+            if (i < alphabets.length - 1 && alphabets[i + 1] == 'A') {
+                int end = getLastA(alphabets, i + 1);
+                move = Math.min(move, i * 2 + (alphabets.length - end));
+                move = Math.min(move, i + (alphabets.length - end) * 2);
+            }
+        }
+
+        return answer + move;
+    }
+
+    public static void main(String[] args) {
+        new Pog_42860().solution("JAN");
+        new Pog_42860().solution("JEROEN");
+        new Pog_42860().solution("AABBCCA");
+        new Pog_42860().solution("FDBSBSFFSDDBSBDBSDAA");
+        new Pog_42860().solution("AAAAAAAAAAAAAAAAAAAA");
+        new Pog_42860().solution("ABAAAAAAAAAAAAAAAAAA");
+        new Pog_42860().solution("BBAAAAAYYY");
+    }
+}


### PR DESCRIPTION
### 신입 사원
> 시간 복잡도 : O(NlogN), 공간 복잡도 : O(N)
 - 정렬 + 그리디 알고리즘 문제
 - 처음에는 서류심사 성적 순위를 내림 차순 정렬 후 순위가 뒤에 있는 것 부터 탐색하여 시간 초과가 남.
 - 반대로 오름 차순으로 정렬 후 앞에 있는 것 부터 탐색하였고, 반복문으로 탐색하면서 min 값보다 현재 interview 값이 순위가 적다면 cnt를 증가하고 min의 값을 현재 interview로 할당 -> 가장 최근에 합격된 신입사원 성적을 기준으로 다음 사원을 판별하면 됨으로 전체 탐색할 필요가 없게 됨 
### 회의실배정 
> 시간 복잡도 : O(NlogN), 공간 복잡도 : O(N)
- 시간 복잡도를 생각해야 한다. 최대 10만개 회의가 있을 수 있다.
- 그리디 알고리즘을 적용하여 푼다. 활동 선택 문제
- 끝나는 시간 순서로 오름차순, 끝나는 순서가 동일할 경우 시작 순서가 빠른 것으로 정렬.
- 최대 갯수를 구해야 한다. 그러기 위해서는 가장 빠른 시간에 끝나는 것을 먼저 선택한다.
- 그리고 겹치는 것을 제외한 나머지들 중 가장 빠른 시간에 시작하는 것을 우선적으로 담는다.


### 카드 정렬하기
> 시간 복잡도 : O(NlogN), 공간 복잡도 : O(N)
- 자료구조 우선순위큐를 사용
- 최솟값을 구하는 것은 숫자가 작은 것들 부터 합산 하면 된다.
- 오름차순으로 이미 정렬 되어있는 값들을 작은 숫자부터 합계를 구하고 합계를 다시 우선순위 큐에 넣는다.
- 우선순위 큐는 작은 숫자가 앞으로 배정
- 큐에서 두 개의 숫자를 가져와 합산 한다. 반복

### 조이스틱
> 시간 복잡도 : O(N), 공간 복잡도 : O(1)
- 좌우 이동 횟수를 구하는 것에 애를 먹었다.
- 연속된 A 가 있을 경우 좌우 이동은 변경될 수 있다.
- 최대 이동 횟수는 N이지만 A가 있을 경우 A는 변경하지 않아도 되기 때문에 방향을 반대로하여 이동 회수를 줄일 수 있다.
- 오른쪽 방향으로 가다가 왼쪽 방향으로 갔을 때
- 왼쪽 방향으로 가다가 오른쪽 방향으로 갔을 때 두가지의 경우를 고려하여 최소 이동 횟수를 구하여야 한다.
